### PR TITLE
Actually added the lines to install verde...

### DIFF
--- a/ubuntu-verde
+++ b/ubuntu-verde
@@ -4,6 +4,8 @@ RUN apt-get -qq install -y cmake gfortran gcc g++ openmpi-bin libopenmpi-dev gms
 RUN wget -O /usr/bin/doxy-coverage https://raw.githubusercontent.com/alobbs/doxy-coverage/master/doxy-coverage.py
 RUN chmod +x /usr/bin/doxy-coverage
 RUN apt-get install -y ksh libglu1-mesa libsm6 libxmu6 libxrender1 libxrandr2 libxcursor1 libxinerama1
+RUN wget https://cubit.sandia.gov/public/downloads/verde2.6-Linux-x86_64.tar.gz
+RUN tar xzvf verde2.6-Linux-x86_64.tar.gz -C /usr/bin/
 ENV PATH=${PATH}:/usr/bin/verde2.6-Linux-x86_64
 
 RUN groupadd -r quinoa


### PR DESCRIPTION
Apparently the previously pushed version forgot the two most important lines: The ones to download and install verde.

This version has been verified to work locally