### PR TITLE
Sonarqube

### DIFF
--- a/alpine
+++ b/alpine
@@ -36,6 +36,6 @@ WORKDIR /home/quinoa
 # Clone quinoa
 RUN git clone https://github.com/quinoacomputing/quinoa.git
 # Build TPLs
-RUN cd quinoa && mkdir -p tpl/build && cd tpl/build && cmake -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_C_COMPILER=mpicc -DCMAKE_Fortran_COMPILER=mpif90 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/home/quinoa/tpl .. && make -sj$((`cat /proc/cpuinfo | grep MHz | wc -l`))
+RUN cd quinoa && mkdir -p tpl/build && cd tpl/build && cmake -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_C_COMPILER=mpicc -DCMAKE_Fortran_COMPILER=mpif90 -DCMAKE_INSTALL_PREFIX=/home/quinoa/tpl .. && make -sj$((`cat /proc/cpuinfo | grep MHz | wc -l`))
 # Remove quinoa
 RUN rm -rf /home/quinoa/quinoa

--- a/alpine
+++ b/alpine
@@ -1,0 +1,41 @@
+# vim: filetype=dockerfile:
+FROM alpine:edge
+
+# Install system-wide prerequisites
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && cat /etc/apk/repositories
+RUN apk update && apk add gfortran gcc g++ make boost-dev openjdk8 ccache pugixml-dev lapack-dev openjdk8 wget bash m4 file git cmake perl grep zlib-dev libexecinfo-dev
+
+# Add glibc for sonarqube wrapper
+ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk /
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub
+RUN apk add glibc-2.25-r0.apk
+
+# Install sonarqube scanner and wrapper
+ADD https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-2.8.zip /
+ADD https://sonarqube.com/static/cpp/build-wrapper-linux-x86.zip /
+RUN mkdir /sonarqube && unzip /sonar-scanner-2.8.zip -d /sonarqube && unzip /build-wrapper-linux-x86.zip -d /sonarqube
+ENV PATH=${PATH}:/sonarqube/build-wrapper-linux-x86:/sonarqube/sonar-scanner-2.8/bin
+RUN rm -rf sonar-scanner-2.8.zip build-wrapper-linux-x86.zip
+
+# Install OpenMPI
+ADD https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.2.tar.gz /openmpi/
+RUN cd /openmpi/ && tar xzf openmpi-2.0.2.tar.gz && cd openmpi-2.0.2 && ./configure --enable-shared --disable-static --enable-mpi-cxx --prefix=/opt/openmpi && make -sj$((`cat /proc/cpuinfo | grep MHz | wc -l`)) install
+ENV PATH /opt/openmpi/bin:$PATH
+ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
+RUN rm -rf /openmpi
+
+# Create symbolic link to /lib/cpp for the charm++ build, see
+# https://lists.cs.illinois.edu/lists/arc/charm/2016-05/msg00013.html
+RUN ln -s /usr/bin/cpp /lib/cpp
+
+# Configure user
+RUN adduser -S quinoa quinoa
+USER quinoa
+WORKDIR /home/quinoa
+
+# Clone quinoa
+RUN git clone https://github.com/quinoacomputing/quinoa.git
+# Build TPLs
+RUN cd quinoa && mkdir -p tpl/build && cd tpl/build && cmake -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_C_COMPILER=mpicc -DCMAKE_Fortran_COMPILER=mpif90 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/home/quinoa/tpl .. && make -sj$((`cat /proc/cpuinfo | grep MHz | wc -l`))
+# Remove quinoa
+RUN rm -rf /home/quinoa/quinoa

--- a/alpine
+++ b/alpine
@@ -19,7 +19,7 @@ RUN rm -rf sonar-scanner-2.8.zip build-wrapper-linux-x86.zip
 
 # Install OpenMPI
 ADD https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.2.tar.gz /openmpi/
-RUN cd /openmpi/ && tar xzf openmpi-2.0.2.tar.gz && cd openmpi-2.0.2 && ./configure --enable-shared --disable-static --enable-mpi-cxx --prefix=/opt/openmpi && make -sj$((`cat /proc/cpuinfo | grep MHz | wc -l`)) install
+RUN cd /openmpi/ && tar xzf openmpi-2.0.2.tar.gz && cd openmpi-2.0.2 && ./configure --enable-shared --disable-static --enable-mpi-cxx --prefix=/opt/openmpi && make -sj$(grep -c processor /proc/cpuinfo) install
 ENV PATH /opt/openmpi/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
 RUN rm -rf /openmpi
@@ -36,6 +36,6 @@ WORKDIR /home/quinoa
 # Clone quinoa
 RUN git clone https://github.com/quinoacomputing/quinoa.git
 # Build TPLs
-RUN cd quinoa && mkdir -p tpl/build && cd tpl/build && cmake -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_C_COMPILER=mpicc -DCMAKE_Fortran_COMPILER=mpif90 -DCMAKE_INSTALL_PREFIX=/home/quinoa/tpl .. && make -sj$((`cat /proc/cpuinfo | grep MHz | wc -l`))
+RUN cd quinoa && mkdir -p tpl/build && cd tpl/build && cmake -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_C_COMPILER=mpicc -DCMAKE_Fortran_COMPILER=mpif90 -DCMAKE_INSTALL_PREFIX=/home/quinoa/tpl .. && make -sj$(grep -c processor /proc/cpuinfo)
 # Remove quinoa
 RUN rm -rf /home/quinoa/quinoa

--- a/alpine
+++ b/alpine
@@ -1,4 +1,3 @@
-# vim: filetype=dockerfile:
 FROM alpine:latest
 
 # Install system-wide prerequisites

--- a/alpine
+++ b/alpine
@@ -1,9 +1,8 @@
 # vim: filetype=dockerfile:
-FROM alpine:edge
+FROM alpine:latest
 
 # Install system-wide prerequisites
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && cat /etc/apk/repositories
-RUN apk update && apk add gfortran gcc g++ make boost-dev openjdk8 ccache pugixml-dev lapack-dev openjdk8 wget bash m4 file git cmake perl grep zlib-dev libexecinfo-dev
+RUN apk update && apk add gfortran gcc g++ make boost-dev openjdk8 ccache lapack-dev openjdk8 wget bash m4 file git cmake perl grep zlib-dev libexecinfo-dev
 
 # Add glibc for sonarqube wrapper
 ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk /


### PR DESCRIPTION
WIP: Removed ubuntu-sonarqube and added alpine dockerfile that is ready for sonarqube. I managed to successfully do a sonarqube analysis inside this alpine image by hand and upload to https://sonarqube.com/dashboard?id=quinoa. Still need to
- [x] configure/finetune the sonarqube analysis, e.g., inclusions, exclusions, etc.
- [x] hook up to travis
- [x] rebase this branch to exclude ubuntu-image attempt before merge
- [x] do not forget to switch branches at docker hub for the automated image build once merged
- [x] set `sonar.projectVersion` to git commit sha1, see also https://docs.sonarqube.org/display/SONAR/Analysis+Parameters